### PR TITLE
Member엔티티에 email필드 추가

### DIFF
--- a/backend/src/main/java/com/pre_38/pre_project/member/entity/Member.java
+++ b/backend/src/main/java/com/pre_38/pre_project/member/entity/Member.java
@@ -18,8 +18,11 @@ public class Member {
     @Column(nullable = false, length = 20)
     private String name;
 
-    @Column
+    @Column(nullable = false)
     private String avatar;
+
+    @Column(nullable = false)
+    private String email;
 
     @Column(nullable = false)
     private LocalDateTime date = LocalDateTime.now();

--- a/backend/src/test/java/com/pre_38/pre_project/restdocs/question/QuestionControllerRestDocsTest.java
+++ b/backend/src/test/java/com/pre_38/pre_project/restdocs/question/QuestionControllerRestDocsTest.java
@@ -72,9 +72,9 @@ public class QuestionControllerRestDocsTest {
         Question question2 = new Question(22L,"나도 모르는 제목2","나도 모르는 내용 2",2);
         Question question3 = new Question(333L,"매우 뛰어난 양질의 제목3","매우 뛰어난 양질의 정보3",333);
 
-        Member member1 = new Member(123L,"초보","123", LocalDateTime.now());
-        Member member2 = new Member(456L,"중수","abc", LocalDateTime.now());
-        Member member3 = new Member(789L,"고수","q1w2e3", LocalDateTime.now());
+        Member member1 = new Member(123L,"초보","123", "naver@naver.com",LocalDateTime.now());
+        Member member2 = new Member(456L,"중수","abc","gmail@gmail.com", LocalDateTime.now());
+        Member member3 = new Member(789L,"고수","q1w2e3", "youtube@youtube.com",LocalDateTime.now());
 
         question1.setMember(member1);
         question2.setMember(member2);
@@ -132,6 +132,7 @@ public class QuestionControllerRestDocsTest {
                                         fieldWithPath("data[].member.name").type(JsonFieldType.STRING).description("회원 이름"),
                                         fieldWithPath("data[].member.avatar").type(JsonFieldType.STRING).description("회원 아바타"),
                                         fieldWithPath("data[].member.date").type(JsonFieldType.STRING).description("가입 날짜"),
+                                        fieldWithPath("data[].member.email").type(JsonFieldType.STRING).description("회원 이메일"),
 
                                         fieldWithPath("pageInfo.page").type(JsonFieldType.NUMBER).description("현재 페이지"),
                                         fieldWithPath("pageInfo.size").type(JsonFieldType.NUMBER).description("페이지 크기"),
@@ -149,7 +150,8 @@ public class QuestionControllerRestDocsTest {
         QuestionDto.Post post = new QuestionDto.Post("아무제목","아무내용","아무유저");
         String content = gson.toJson(post);
         QuestionDto.response responseDto =
-                new QuestionDto.response(1L,"아무제목","아무내용",LocalDateTime.now(),0,new Member(1L,"아무유저","1234",LocalDateTime.now()));
+                new QuestionDto.response(1L,"아무제목","아무내용",LocalDateTime.now(),0,new Member(1L,"아무유저","1234",
+                        "naver@naver.com",LocalDateTime.now()));
 
         given(mapper.questionPostToQuestion(Mockito.any(QuestionDto.Post.class))).willReturn(new Question());
         given(memberService.findMember(Mockito.anyString())).willReturn(new Member());
@@ -195,7 +197,8 @@ public class QuestionControllerRestDocsTest {
                                         fieldWithPath("data.member.memberId").type(JsonFieldType.NUMBER).description("작성자 아이디"),
                                         fieldWithPath("data.member.name").type(JsonFieldType.STRING).description("작성자 닉네임"),
                                         fieldWithPath("data.member.avatar").type(JsonFieldType.STRING).description("작성자 아바타"),
-                                        fieldWithPath("data.member.date").type(JsonFieldType.STRING).description("작성자 가입 날짜")
+                                        fieldWithPath("data.member.date").type(JsonFieldType.STRING).description("작성자 가입 날짜"),
+                                        fieldWithPath("data.member.email").type(JsonFieldType.STRING).description("작성자 이메일")
                                 )
                         )
                 ));
@@ -233,7 +236,8 @@ public class QuestionControllerRestDocsTest {
         //given
         long questionId = 1L;
         QuestionDto.response responseDto =
-                new QuestionDto.response(1L,"아무제목","아무내용",LocalDateTime.now(),0,new Member(1L,"아무유저","1234",LocalDateTime.now()));
+                new QuestionDto.response(1L,"아무제목","아무내용",LocalDateTime.now(),0,new Member(1L,"아무유저","1234",
+                        "naver@naver.com",LocalDateTime.now()));
 
         given(questionService.findQuestion(Mockito.anyLong())).willReturn(new Question());
         given(mapper.questionToQuestionResponse(Mockito.any(Question.class))).willReturn(responseDto);
@@ -253,6 +257,7 @@ public class QuestionControllerRestDocsTest {
                 .andExpect(jsonPath("$.data.votes").value(responseDto.getVotes()))
                 .andExpect(jsonPath("$.data.member.name").value(responseDto.getMember().getName()))
                 .andExpect(jsonPath("$.data.member.avatar").value(responseDto.getMember().getAvatar()))
+                .andExpect(jsonPath("$.data.member.email").value(responseDto.getMember().getEmail()))
                 .andDo(document(
                         "get-question",
                         preprocessRequest(prettyPrint()),
@@ -272,7 +277,8 @@ public class QuestionControllerRestDocsTest {
                                         fieldWithPath("data.member.memberId").type(JsonFieldType.NUMBER).description("작성자 아이디"),
                                         fieldWithPath("data.member.name").type(JsonFieldType.STRING).description("작성자 닉네임"),
                                         fieldWithPath("data.member.avatar").type(JsonFieldType.STRING).description("작성자 아바타"),
-                                        fieldWithPath("data.member.date").type(JsonFieldType.STRING).description("작성자 가입 날짜")
+                                        fieldWithPath("data.member.date").type(JsonFieldType.STRING).description("작성자 가입 날짜"),
+                                        fieldWithPath("data.member.email").type(JsonFieldType.STRING).description("작성자 이메일")
                                 )
                         )
                 ));


### PR DESCRIPTION
# PR 요청 내용

[ PR 요청내용을 적어주세요. 상세하면 더욱더 좋습니다. ]
ex) Oauth 2.0을 이용해서 카카오 로그인 & 카카오 로그아웃 기능을 추가했습니다.

1. 디렉터리 구조를 수정 하였습니다. 루트에 있던 스프링을 backend파일에 넣어 추후 통합에도 용이하게 구조를 변경하였습니다.
2. Member엔티티에 email필드 추가하여 이메일 정보도 담을 수 있도록 하였습니다.


# 참고 링크 & 스크린샷

[ Issues 해결에 관한 도움을 줄 수 있는 링크나 스크린샷을 올려주세요. Issues가 없으면 지워주세요. ]


![1](https://user-images.githubusercontent.com/84536269/186805625-f0b47538-fbcc-4f9b-bc0d-3760fc8ee9d7.png)


# 체크리스트 

- [x] git commit message 준수   
Ex) docs: 파일명 파일 상태
- [x] Pull Request 대상 파일 확인
- [x] Branch 확인
- [x] Labels 확인